### PR TITLE
htmdecoder: Add software TLB, fixes and cleanups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,5 +53,5 @@ ptracer_ptracer_SOURCES = \
 ptracer_ptracer_LDADD = libqtrace.a
 
 htm_htmdecoder_SOURCES = \
-	htm/htm.c htm/htmdecoder.c
+	htm/htm.c htm/htmdecoder.c htm/tlb.c
 htm_htmdecoder_LDADD = libqtrace.a

--- a/htm/htm.c
+++ b/htm/htm.c
@@ -779,11 +779,11 @@ static int htm_decode_insn(struct htm_decode_state *state,
 			htm_rewind(state, value);
 		}
 
-		if (insn.ira.page_size == 1) {
+		if (insn.ira.page_size == 12) {
 			state->stat.total_instruction_pages_4k++;
-		} else if (insn.ira.page_size == 2) {
+		} else if (insn.ira.page_size == 16) {
 			state->stat.total_instruction_pages_64k++;
-		} else if (insn.ira.page_size == 3) {
+		} else if (insn.ira.page_size == 24) {
 			state->stat.total_instruction_pages_16m++;
 		}
 

--- a/htm/htm.c
+++ b/htm/htm.c
@@ -934,8 +934,6 @@ static int htm_decode_insn(struct htm_decode_state *state,
 		rec.insn.data_page_shift_valid = false;
 	}
 
-	rec.insn.branch = insn.info.branch;
-
 	if (state->fn)
 		state->fn(&rec, state->private_data);
 

--- a/htm/htm.c
+++ b/htm/htm.c
@@ -429,7 +429,7 @@ static int htm_decode_insn_ira(struct htm_decode_state *state,
 			return -1;
 	}
 
-	address = htm_bits(value, 0, 37) << rec->page_size;
+	address = htm_bits(value, 0, 37) << 12;
 	mask = 1;
 	mask = (mask << rec->page_size) - 1;
 
@@ -904,7 +904,7 @@ static int htm_decode_insn(struct htm_decode_state *state,
 
 	if (insn.info.ira && !insn.info.esid && insn.ira.page_size > 0) {
 		rec.insn.insn_ra_valid = true;
-		rec.insn.insn_ra = insn.ira.address >> insn.ira.page_size;
+		rec.insn.insn_ra = insn.ira.address;
 		rec.insn.insn_page_shift_valid = true;
 		rec.insn.insn_page_shift = insn.ira.page_size;
 	} else {

--- a/htm/htm.c
+++ b/htm/htm.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 
 #include "htm.h"
+#include "tlb.h"
 
 #define HTM_STAMP_RECORD	0xACEFF0
 #define HTM_STAMP_COMPLETE	0xACEFF1
@@ -723,13 +724,28 @@ int opcode_type(uint32_t opcode)
 	}
 }
 
+/* This is basically ilog2() */
+static unsigned int pagesize_to_shift(uint64_t size)
+{
+	if (size == 4096)
+		return 12;
+	if (size == 65536)
+		return 16;
+	if (size == 16777216)
+		return 24;
+	assert(1);
+	return 0;
+}
+
 static int htm_decode_insn(struct htm_decode_state *state,
 			   uint64_t value)
 {
 	struct htm_insn insn = { 0 };
 	struct htm_record rec;
+	uint64_t tlb_flags, tlb_pagesize;
 	int optype;
 	int ret;
+	bool software_tlb;
 
 	state->stat.total_records_processed++;
 	state->stat.total_instruction_scanned++;
@@ -745,6 +761,7 @@ static int htm_decode_insn(struct htm_decode_state *state,
 		goto fail;
 	}
 
+	software_tlb = false;
 	if (insn.info.iea) {
 		ret = htm_decode_fetch(state, &value);
 		if (ret < 0) {
@@ -759,12 +776,24 @@ static int htm_decode_insn(struct htm_decode_state *state,
 			htm_rewind(state, value);
 		} else {
 			state->insn_addr = insn.iea.address;
+			tlb_flags = insn.iea.msrir ? TLB_FLAGS_RELOC : 0;
+			/* Only lookup translation in the TLB if we
+			 * didn't get one in the trace
+			 */
+			if (!insn.info.ira &&
+			    tlb_ra_get(state->insn_addr, tlb_flags,
+				       &insn.ira.address, &tlb_pagesize) ){
+				insn.info.ira = true;
+				insn.ira.page_size = pagesize_to_shift(tlb_pagesize);
+				insn.ira.esid_to_irpn = 0; // FIXME ??
+				software_tlb = true;
+			}
 		}
 	} else {
 		state->insn_addr += 4;
 	}
 
-	if (insn.info.ira) {
+	if (insn.info.ira & !software_tlb) {
 		ret = htm_decode_fetch(state, &value);
 		if (ret < 0) {
 			goto fail;
@@ -791,6 +820,10 @@ static int htm_decode_insn(struct htm_decode_state *state,
 			state->stat.instructions_without_i_vsid++;
 		}
 
+		tlb_flags = insn.iea.msrir ? TLB_FLAGS_RELOC : 0;
+		tlb_pagesize = 1 << insn.ira.page_size;
+		tlb_ra_set(state->insn_addr, tlb_flags, insn.ira.address,
+			   tlb_pagesize);
 		state->stat.instructions_with_ira++;
 	} else {
 		state->stat.instructions_without_ira++;
@@ -998,6 +1031,8 @@ int htm_decode(int fd, htm_record_fn_t fn, void *private_data,
 		.private_data = private_data,
 	};
 
+	tlb_init();
+
 	do {
 		ret = htm_decode_one(&state);
 	} while (ret > 0);
@@ -1005,6 +1040,8 @@ int htm_decode(int fd, htm_record_fn_t fn, void *private_data,
 	if (result != NULL) {
 		*result = state.stat;
 	}
+
+	tlb_exit();
 
 	return ret;
 }

--- a/htm/htm.c
+++ b/htm/htm.c
@@ -103,8 +103,6 @@ static void htm_rewind(struct htm_decode_state *state, uint64_t value)
 	word1 = htm_bits(value, 0, 31);
 	word2 = htm_bits(value, 32, 63);
 	state->stat.checksum -= (word1 + word2);
-
-	printf("%s %i %016lx\n", __func__, state->nr, state->stat.checksum);
 }
 
 static int htm_decode_fetch(struct htm_decode_state *state, uint64_t *value)

--- a/htm/htmdecoder.c
+++ b/htm/htmdecoder.c
@@ -20,6 +20,7 @@
 #include <qtlib/qtwriter.h>
 
 #include "htm.h"
+#include "tlb.h"
 
 static void print_record_record(struct htm_record_record *r)
 {
@@ -190,6 +191,7 @@ static void print_stat(struct htm_decode_stat *stat)
 	printf("%48s : %u\n", "4K instruction pages", stat->total_instruction_pages_4k);
 	printf("%48s : %u\n", "64K instruction pages", stat->total_instruction_pages_64k);
 	printf("%48s : %u\n", "16M instruction pages", stat->total_instruction_pages_16m);
+	tlb_dump();
 }
 
 static void usage(const char *prog)

--- a/htm/htmdecoder.c
+++ b/htm/htmdecoder.c
@@ -80,14 +80,18 @@ static void print_record_time(struct htm_record_time *r)
 static void print_record_insn(struct qtrace_record *r)
 {
 	printf("INSN ");
-	printf(" iea:0x%016"PRIx64" ", r->insn_addr);
+	printf(" iea:%016"PRIx64, r->insn_addr);
 	printf(" op:%08x", r->insn);
+	if (r->insn_ra_valid)
+		printf(" ira:%016"PRIx64, r->insn_ra);
+	if (r->insn_page_shift_valid)
+		printf(" ira:%i", r->insn_page_shift);
 	if (r->data_addr_valid)
 		printf(" dea:%016"PRIx64, r->data_addr);
 	if (r->data_ra_valid)
 		printf(" dra:%016"PRIx64, r->data_ra);
 	if (r->data_page_shift_valid)
-		printf(" pgsize:%i", r->data_page_shift);
+		printf(" dpgsize:%i", r->data_page_shift);
 	printf("\n");
 }
 

--- a/htm/tlb.c
+++ b/htm/tlb.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2018 Michael Neuling <mikey@linux.ibm.com>, IBM
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version
+ * 2 of the License, or (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <endian.h>
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "tlb.h"
+
+#define TLB_SIZE 256
+#define TLB_FLAGS_AVALIABLE (TLB_FLAGS_RELOC)
+struct tlbe {
+	uint64_t ea;
+	uint64_t ra;
+	uint64_t size;
+	uint64_t flags;
+	uint64_t hit_count;
+	uint64_t miss_count;
+	bool valid;
+};
+struct tlb_cache {
+	struct tlbe tlb[TLB_SIZE];
+	int next;
+	int translations;
+	int no_translation;
+	int translation_changes;
+};
+struct tlb_cache tlb;
+
+int tlb_debug = 0;
+
+static inline uint64_t tlb_mask_offset(struct tlbe *t)
+{
+	return t->size - 1;
+}
+
+static inline uint64_t tlb_mask_rpn(struct tlbe *t)
+{
+	return ~(tlb_mask_offset(t));
+}
+
+static inline void tlb_pagesize_validate(uint64_t size)
+{
+	assert((size == 4096) || (size == 65536) || (size == 16777216));
+}
+
+static inline void tlb_flags_validate(uint64_t flags)
+{
+	assert((flags & ~(TLB_FLAGS_AVALIABLE)) == 0);
+}
+
+static bool tlb_equal(struct tlbe *t1, struct tlbe *t2)
+{
+	if (t1->ea != t2->ea)
+		return false;
+	if (t1->ra != t2->ra)
+		return false;
+	if (t1->size != t2->size)
+		return false;
+	if (t1->flags != t2->flags)
+		return false;
+	if (t1->valid != t2->valid)
+		return false;
+	/* Don't check count */
+
+	return true;
+}
+
+static inline void tlb_entry_validate(struct tlbe *t)
+{
+	uint64_t mask;
+
+	assert(t->valid);
+	tlb_pagesize_validate(t->size);
+	tlb_flags_validate(t->flags);
+	mask = tlb_mask_offset(t);
+	assert((t->ea & mask) == 0);
+	assert((t->ra & mask) == 0);
+}
+
+static inline void tlb_print(struct tlbe *t)
+{
+	printf("ea:%016"PRIx64" ra:%016"PRIx64" size:%08"PRIx64" "
+	       "flags:%"PRIx64" miss:%"PRIi64" hit:%"PRIi64"\n",
+	       t->ea, t->ra, t->size, t->flags, t->miss_count, t->hit_count);
+}
+
+void tlb_dump(void)
+{
+	int i;
+
+	for (i = 0; i < tlb.next; i++) {
+		printf("TLBDUMP %02i: ", i);
+		tlb_print(&tlb.tlb[i]);
+	}
+	printf("TLBDUMP no translation: %i of %i\n",
+	       tlb.no_translation, tlb.translations);
+	printf("TLBDUMP replaced translations: %i\n",
+	       tlb.translation_changes);
+}
+
+static inline bool tlb_match(uint64_t ea, uint64_t flags, struct tlbe *t)
+{
+	tlb_entry_validate(t);
+
+	if (tlb_debug > 0) {
+		printf("%s ea:%016"PRIx64" flags:%"PRIx64" ",
+		       __func__, ea, flags);
+		tlb_print(t);
+	}
+
+	if (ea < t->ea)
+		return false;
+	if (ea >= (t->ea + t->size))
+		return false;
+	if (flags != t->flags)
+		return false;
+
+	return true;
+}
+
+
+static inline int __tlb_get_index(uint64_t ea, uint64_t flags, int start)
+{
+	struct tlbe *t;
+	int i;
+
+	/* FIXME: linear search... *barf* */
+	for (i = start; i < tlb.next; i++) {
+		t = &tlb.tlb[i];
+		if (tlb_match(ea, flags, t)) {
+			tlb_entry_validate(t);
+			/* This hit in the hardware hence we had to do
+			 * the translation
+			 */
+			t->hit_count++;
+			return i;
+		}
+	}
+	return -1;
+}
+
+static inline int tlb_get_index(uint64_t ea, uint64_t flags)
+{
+	return __tlb_get_index(ea, flags, 0);
+}
+
+static inline void tlb_validate(void)
+{
+	struct tlbe *t;
+	int i;
+	bool valid_last;
+
+	assert(tlb.next <= TLB_SIZE);
+
+	/* Check for overlaps */
+	for (i = 0; i < tlb.next; i++) {
+		t = &tlb.tlb[i];
+		/* Check this ea doesn't match other entries */
+		/* Check start of page */
+		assert(__tlb_get_index(t->ea, t->flags, i + 1) == -1);
+		/* Check end page */
+		assert(__tlb_get_index(t->ea + t->size - 1, t->flags, i + 1)
+		       == -1);
+	}
+
+	/* Check for holes */
+	valid_last = true;
+	for (i = 0; i < TLB_SIZE; i++) {
+		t = &tlb.tlb[i];
+		assert(!t->valid || valid_last);
+		valid_last = t->valid;
+	}
+}
+
+static inline uint64_t tlb_translate(uint64_t ea, uint64_t flags,
+				     struct tlbe *t)
+{
+	uint64_t ra;
+
+	/* Double check this is a match */
+	assert(ea >= t->ea);
+	assert(ea < (t->ea + t->size));
+	/* Other checks */
+	tlb_flags_validate(flags); /* flags unused other than this check */
+	tlb_entry_validate(t);
+
+	/* Actual translation */
+	ra = ea & tlb_mask_offset(t);
+	ra |= t->ra & tlb_mask_rpn(t);
+
+	return ra;
+}
+
+void tlb_init(void)
+{
+	memset(&tlb, 0, sizeof(tlb));
+	tlb_validate();
+}
+
+void tlb_exit(void)
+{
+	tlb_validate();
+}
+
+bool tlb_ra_get(uint64_t ea, uint64_t flags,
+		uint64_t *ra, uint64_t *pagesize)
+{
+	struct tlbe *t;
+	int index;
+
+	assert(ra);
+	assert(pagesize);
+
+	tlb.translations++;
+	/* Find entry */
+	index = tlb_get_index(ea, flags);
+	if (index < 0) {
+		tlb.no_translation++;
+		return false;
+	}
+
+	/* Get entry */
+	t = &tlb.tlb[index];
+
+	/* Do translation */
+	*ra = tlb_translate(ea, flags, t);
+	*pagesize = t->size;
+
+	return true;
+}
+
+/*
+ * Set a new entry.
+ * If old entry exists, delete it
+ */
+void tlb_ra_set(uint64_t ea, uint64_t flags,
+		uint64_t ra, uint64_t pagesize)
+{
+	struct tlbe *t;
+	struct tlbe tnew;
+	int index;
+
+//	tlb_debug = 1;
+
+
+	tlb_pagesize_validate(pagesize);
+	tlb_flags_validate(flags);
+
+	index = tlb_get_index(ea, flags);
+	if (index < 0) {
+		/* No entry found, so put it at the end */
+		index = tlb.next;
+		tlb.next++;
+		assert(tlb.next <= TLB_SIZE);
+	}
+	tlb_debug = 0;
+
+	t = &tlb.tlb[index];
+
+	/* Generate new entry */
+	tnew.size = pagesize;
+	tnew.ea = ea & tlb_mask_rpn(&tnew);
+	tnew.ra = ra & tlb_mask_rpn(&tnew);
+	tnew.flags = flags;
+	tnew.valid = true;
+
+	if (tlb_equal(&tnew, t)) {
+		/* This missed in the hardware */
+		t->miss_count++;
+		return;
+	} else if (t->valid) { /* new entry */
+		/* Same RA but different RA */
+		tlb.translation_changes++;
+		/*
+		printf("TLB different: %i\n", index);
+		printf("TLB Existing: "); tlb_print(t);
+		printf("TLB New:      "); tlb_print(&tnew);
+		*/
+	}
+
+	/* Set entry */
+	memcpy(t, &tnew, sizeof(tnew));
+
+	/* Check if we've screwed something up  */
+	tlb_validate();
+}

--- a/htm/tlb.h
+++ b/htm/tlb.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Michael Neuling <mikey@linux.ibm.com>, IBM
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version
+ * 2 of the License, or (at your option) any later version.
+ */
+
+
+#ifndef __TLB_H__
+#define __TLB_H__
+
+#include <stdint.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+#define TLB_FLAGS_RELOC (1 << 0)
+
+extern void tlb_init(void);
+extern void tlb_exit(void);
+extern void tlb_dump(void);
+
+/* Setup a translation */
+extern void tlb_ra_set(uint64_t ea, uint64_t flags,
+		       uint64_t ra, uint64_t pagesize);
+
+/* Do a translation */
+extern bool tlb_ra_get(uint64_t ea, uint64_t flags,
+		       uint64_t *ra, uint64_t *pagesize);
+
+#endif /* __TLB_H__ */


### PR DESCRIPTION
This adds a software TLB to create a real address for all taken branches.

Also has a bunch of cleanups and some fixes to match the older qtrace encoder.