### PR TITLE
Fixes for compiler warnings and errors

### DIFF
--- a/htm/htm.c
+++ b/htm/htm.c
@@ -740,7 +740,7 @@ static unsigned int pagesize_to_shift(uint64_t size)
 static int htm_decode_insn(struct htm_decode_state *state,
 			   uint64_t value)
 {
-	struct htm_insn insn = { 0 };
+	struct htm_insn insn = { { 0 } };
 	struct htm_record rec;
 	uint64_t tlb_flags, tlb_pagesize;
 	int optype;

--- a/qtdis/qtdis.c
+++ b/qtdis/qtdis.c
@@ -230,11 +230,13 @@ static bool show_raw_insn;
 
 static void print_insn(uint32_t insn, unsigned int len)
 {
+	unsigned int i;
+
 	if (show_raw_insn) {
 		uint8_t *p = (uint8_t *)(uint32_t *)&insn;
 
 		fprintf(stdout, "\t");
-		for (unsigned long i = 0; i < len; i++)
+		for (i = 0; i < len; i++)
 			fprintf(stdout, "%02x ", p[i]);
 	}
 }
@@ -446,13 +448,13 @@ static unsigned long parse_record(void *p, unsigned long *ea)
 	uint32_t insn;
 	uint16_t flags, flags2 = 0, flags3 = 0;
 	uint64_t iar = 0;
-	uint64_t iar_rpn;
-	uint64_t iar_seq_rpn;
-	uint8_t iar_page_size;
-	uint8_t iar_seq_page_size;
+	uint64_t iar_rpn = 0;
+	uint64_t iar_seq_rpn = 0;
+	uint8_t iar_page_size = 0;
+	uint8_t iar_seq_page_size = 0;
 	uint64_t data_address = 0;
-	uint32_t data_rpn;
-	uint8_t data_page_size;
+	uint32_t data_rpn = 0;
+	uint8_t data_page_size = 0;
 	uint8_t node = 0;
 	uint8_t term_node = 0, term_code = 0;
 	void *q;


### PR DESCRIPTION
This fixes a bunch of compiler errors on 4.8 (RHEL7):

htm/htm.c:743:9: error: missing braces around initializer [-Werror=missing-braces]
  struct htm_insn insn = { 0 };
         ^

qtdis/qtdis.c:237:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (unsigned long i = 0; i < len; i++)
   ^

qtdis/qtdis.c:714:11: error: ‘iar_rpn’ may be used uninitialized in this function [-Werror=maybe-uninitialized]

<and more>

Signed-off-by: Michael Neuling <mikey@neuling.org>