### PR TITLE
htmdecode/tlb: Some performance and printing enhancments

### DIFF
--- a/htm/tlb.c
+++ b/htm/tlb.c
@@ -274,6 +274,9 @@ void tlb_allocate(void)
 	memset(t, 0, tlb.size*sizeof(struct tlbe));
 	tlb.size = size_new;
 
+	/* Since we do a linear search, sort once in a while to help with hit rate */
+	tlb_sort();
+
 	tlb_validate();
 	return;
 }

--- a/htm/tlb.c
+++ b/htm/tlb.c
@@ -227,6 +227,28 @@ bool tlb_ra_get(uint64_t ea, uint64_t flags,
 	return true;
 }
 
+/* Stupid bubble sort of tlb entries by hits */
+void tlb_sort(void)
+{
+	struct tlbe t;
+	int i, j;
+	bool swap;
+
+	for (i = 0; i < tlb.next; i++) {
+		swap = false;
+		for (j = 0; j < tlb.next - 1; j++) {
+			if (tlb.tlb[j+1].hit_count > tlb.tlb[j].hit_count ) {
+				t = tlb.tlb[j+1];
+				tlb.tlb[j+1] = tlb.tlb[j];
+				tlb.tlb[j] = t;
+				swap = true;
+			}
+		}
+		if (!swap)
+			break;
+	}
+}
+
 void tlb_allocate(void)
 {
 	int size_new;
@@ -259,6 +281,8 @@ void tlb_allocate(void)
 void tlb_dump(void)
 {
 	int i;
+
+	tlb_sort();
 
 	for (i = 0; i < tlb.next; i++) {
 		printf("TLBDUMP %02i: ", i);

--- a/htm/tlb.c
+++ b/htm/tlb.c
@@ -97,20 +97,6 @@ static inline void tlb_print(struct tlbe *t)
 	       t->ea, t->ra, t->size, t->flags, t->miss_count, t->hit_count);
 }
 
-void tlb_dump(void)
-{
-	int i;
-
-	for (i = 0; i < tlb.next; i++) {
-		printf("TLBDUMP %02i: ", i);
-		tlb_print(&tlb.tlb[i]);
-	}
-	printf("TLBDUMP no translation: %i of %i\n",
-	       tlb.no_translation, tlb.translations);
-	printf("TLBDUMP replaced translations: %i\n",
-	       tlb.translation_changes);
-}
-
 static inline bool tlb_match(uint64_t ea, uint64_t flags, struct tlbe *t)
 {
 	tlb_entry_validate(t);
@@ -268,6 +254,20 @@ void tlb_allocate(void)
 
 	tlb_validate();
 	return;
+}
+
+void tlb_dump(void)
+{
+	int i;
+
+	for (i = 0; i < tlb.next; i++) {
+		printf("TLBDUMP %02i: ", i);
+		tlb_print(&tlb.tlb[i]);
+	}
+	printf("TLBDUMP no translation: %i of %i\n",
+	       tlb.no_translation, tlb.translations);
+	printf("TLBDUMP replaced translations: %i\n",
+	       tlb.translation_changes);
 }
 
 /*


### PR DESCRIPTION
Sort by hits before we dump
- Makes it easier to read.

Sort by hits when we allocate more entries
- This makes the linear search of the TLB go faster (although I've not
  actually been able to measure a performance improvement).
