### PR TITLE
Add basic blocks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,11 +3,16 @@ AUTOMAKE_OPTIONS = foreign
 AM_CFLAGS = -Wall -Werror -O2 \
 	    -I$(top_srcdir)/qtlib
 
-lib_LIBRARIES = libqtrace.a libppcstats.a
+lib_LIBRARIES = libqtrace.a libppcstats.a libbb.a
 
 libqtrace_a_SOURCES = qtlib/qtreader.c qtlib/qtwriter.c
 
 libppcstats_a_SOURCES = qtlib/ppcstats.c
+
+libbb_a_SOURCES = qtlib/bb.c \
+	qtrace-bbv/ccan/hash/hash.c \
+	qtrace-bbv/ccan/htable/htable.c
+libbb_a_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/qtrace-bbv
 
 qtlib_TESTS = qtlib/tests/test1 qtlib/tests/test2 \
 	      qtlib/tests/test3 qtlib/tests/test4
@@ -34,7 +39,7 @@ branch_link_stack_SOURCES = branch/link_stack.c
 branch_link_stack_LDADD = libqtrace.a
 
 qtdis_qtdis_SOURCES = qtdis/qtdis.c
-qtdis_qtdis_LDADD = libqtrace.a libppcstats.a
+qtdis_qtdis_LDADD = libqtrace.a libppcstats.a libbb.a
 
 qtrace_bbv_qtrace_bbv_SOURCES = \
 	qtrace-bbv/ccan/hash/hash.c \
@@ -56,4 +61,4 @@ ptracer_ptracer_LDADD = libqtrace.a
 
 htm_htmdecoder_SOURCES = \
 	htm/htm.c htm/htmdecoder.c htm/tlb.c
-htm_htmdecoder_LDADD = libqtrace.a libppcstats.a
+htm_htmdecoder_LDADD = libqtrace.a libppcstats.a libbb.a

--- a/htm/htm.c
+++ b/htm/htm.c
@@ -19,6 +19,7 @@
 
 #include "htm.h"
 #include "tlb.h"
+#include "bb.h"
 
 #define HTM_STAMP_RECORD	0xACEFF0
 #define HTM_STAMP_COMPLETE	0xACEFF1
@@ -809,6 +810,8 @@ static int htm_decode_insn(struct htm_decode_state *state,
 	} else {
 		state->insn_addr += 4;
 	}
+	// FIXME: skip if stats only
+	bb_ea_log(state->insn_addr);
 
 	if (insn.info.ira & !insn.info.software_tlb) {
 		ret = htm_decode_fetch(state, &value);
@@ -1084,6 +1087,7 @@ int htm_decode(int fd, htm_record_fn_t fn, void *private_data,
 	};
 
 	tlb_init();
+	bb_init();
 
 	do {
 		ret = htm_decode_one(&state);

--- a/qtlib/bb.c
+++ b/qtlib/bb.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2018 Michael Neuling <mikey@linux.ibm.com>, IBM
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version
+ * 2 of the License, or (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <endian.h>
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include "bb.h"
+#include "ccan/hash/hash.h"
+#include "ccan/htable/htable_type.h"
+
+struct obj {
+	uint64_t ea;
+	int index;
+};
+
+static const uint64_t *objea(const struct obj *obj)
+{
+	return &obj->ea;
+}
+
+static size_t objhash(const uint64_t *ea)
+{
+	return hash64(ea, 1, 0);
+}
+
+static bool cmp(const struct obj *obj1, const uint64_t *ea)
+{
+	return obj1->ea == *ea;
+}
+
+HTABLE_DEFINE_TYPE(struct obj, objea, objhash, cmp, htable_obj);
+
+
+struct bbe {
+	uint64_t ea;
+	uint64_t size;
+	uint64_t hit_count;
+	bool valid;
+};
+struct bb_cache {
+	struct htable_obj ht;
+	struct bbe *bb;
+	int size;
+	int next;
+};
+struct bb_cache bb;
+
+int bb_debug = 0;
+
+static inline void bb_print(struct bbe *t)
+{
+	printf("ea:%016"PRIx64" size:% 3"PRId64" "
+	       "hit:%"PRIi64"\n",
+	       t->ea, t->size, t->hit_count);
+}
+
+static int bb_compare_ea(const void *a, const void *b)
+{
+
+	struct bbe *bbe_a = (struct bbe *)a;
+	struct bbe *bbe_b = (struct bbe *)b;
+
+	if (bbe_a->ea < bbe_b->ea)
+		return -1;
+	else if (bbe_a->ea > bbe_b->ea)
+		return 1;
+	else if (bbe_a->size < bbe_b->size)
+		return -1;
+	else if (bbe_a->size > bbe_b->size)
+		return 1;
+	else
+		return 0;
+}
+
+static int bb_compare_hit(const void *a, const void *b)
+{
+
+	struct bbe *bbe_a = (struct bbe *)a;
+	struct bbe *bbe_b = (struct bbe *)b;
+
+	if (bbe_a->valid && !bbe_b->valid)
+		return -1;
+	else if (!bbe_a->valid && bbe_b->valid)
+		return 1;
+	else if (bbe_a->hit_count > bbe_b->hit_count)
+		return -1;
+	else if (bbe_a->hit_count < bbe_b->hit_count)
+		return 1;
+	else
+		return 0;
+}
+
+void bb_allocate(void)
+{
+	int size_new;
+
+	struct bbe *t;
+//	printf("Allocating new BB size: %i\n", bb.size);
+
+	if (!bb.bb) {
+		if (!htable_obj_init_sized(&bb.ht, 1000000)) {
+			fprintf(stderr, "htable_obj_init_sized failed\n");
+			exit(1);
+		}
+		/* Allocate initial BB */
+		bb.bb = malloc(sizeof(struct bbe));
+		assert(bb.bb);
+		bb.size = 1;
+		memset(bb.bb, 0, sizeof(struct bbe));
+		return;
+	}
+
+	/* Double the size of the BB */
+	size_new = bb.size * 2;
+	bb.bb = realloc(bb.bb, size_new*sizeof(struct bbe));
+	assert(bb.bb);
+	/* zero new part */
+	t = &bb.bb[bb.size];
+	memset(t, 0, bb.size*sizeof(struct bbe));
+	bb.size = size_new;
+
+//	bb_validate();
+	return;
+}
+
+void bb_init(void)
+{
+	bb_allocate();
+}
+
+/* descructive */
+void bb_coalesce(void)
+{
+	struct bbe *ttest;
+	struct bbe *t;
+	uint64_t ea;
+	int i;
+
+	ttest = &bb.bb[0];
+	ea = ttest->ea;
+	/* Coalesce consecutive entres with same hit count & incrementing ea */
+	for (i = 1; i < bb.next; i++) {
+		t = &bb.bb[i];
+		if ((t->ea == ea + 4) && (t->hit_count == ttest->hit_count)) {
+			t->valid = 0;
+			ea = t->ea;
+			ttest->size++;
+		} else {
+			ttest = t;
+			ea = ttest->ea;
+		}
+	}
+	qsort(bb.bb, bb.next, sizeof(struct bbe), bb_compare_hit);
+	for (i = 0; i < bb.next; i++)
+		if (!bb.bb[i].valid)
+			bb.next = i;
+}
+
+/* This is descritive of the entries when sort= true */
+static void __bb_dump(bool sort)
+{
+	int i;
+
+	if (sort) {
+		qsort(bb.bb, bb.next, sizeof(struct bbe), bb_compare_ea);
+		bb_coalesce();
+		qsort(bb.bb, bb.next, sizeof(struct bbe), bb_compare_hit);
+	}
+	for (i = 0; i < bb.next; i++) {
+		printf("BBDUMP %02i: ", i);
+		bb_print(&bb.bb[i]);
+	}
+	// put back in binary search order
+}
+void bb_dump(void)
+{
+	__bb_dump(true);
+}
+
+void bb_ea_log(uint64_t ea)
+{
+	struct bbe *t;
+
+//	bb_debug = 1;
+//
+	struct obj *obj;
+
+	obj = htable_obj_get(&bb.ht, &ea);
+	if (obj) {
+		t = &bb.bb[obj->index];
+		t->hit_count++;
+		return;
+	}
+	/* Didn't find the entry */
+	if (bb.size == bb.next)
+		bb_allocate();
+
+	t = &bb.bb[bb.next];
+	/* Generate new entry */
+	t->size = 1; // FIXME for basic blocks
+	t->ea = ea;
+	t->valid = true;
+	t->hit_count = 1;
+
+	obj = malloc(sizeof(*obj));
+	assert(obj);
+	obj->ea = ea;
+	obj->index = bb.next;
+	htable_obj_add(&bb.ht, obj);
+
+	bb.next++;
+}

--- a/qtlib/bb.h
+++ b/qtlib/bb.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2018 Michael Neuling <mikey@linux.ibm.com>, IBM
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version
+ * 2 of the License, or (at your option) any later version.
+ */
+
+
+#ifndef __BB_H__
+#define __BB_H__
+
+#include <stdint.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+extern void bb_init(void);
+extern void bb_exit(void);
+extern void bb_dump(void);
+
+/* Setup a translation */
+extern void bb_ea_log(uint64_t ea);
+
+#endif /* __BB_H__ */


### PR DESCRIPTION
This adds basic block tracking to qtdis and htmdecoder.  Output looks like:
        BBDUMP 00: ea:c0000000000023b0 size: 35 hit:136640
        BBDUMP 01: ea:0000729d1b1b6250 size: 10 hit:42386
        BBDUMP 02: ea:000071085c047cfc size:  3 hit:38648
        BBDUMP 03: ea:000071085c46d4bc size: 16 hit:36861
        BBDUMP 04: ea:000071085c46d4b8 size:  1 hit:36857
        BBDUMP 05: ea:000071085c44f978 size:  6 hit:23904
        BBDUMP 06: ea:000071085c44f96c size:  2 hit:23896
        BBDUMP 07: ea:000071085c44f974 size:  1 hit:23895

It's rebased on pull request #16 hence has that code also.