### PR TITLE
qtlib/bb: Coalesce better

### DIFF
--- a/qtlib/bb.c
+++ b/qtlib/bb.c
@@ -154,7 +154,7 @@ void bb_coalesce(void)
 	/* Coalesce consecutive entres with same hit count & incrementing ea */
 	for (i = 1; i < bb.next; i++) {
 		t = &bb.bb[i];
-		if ((t->ea == ea + 4) && (t->hit_count == ttest->hit_count)) {
+		if ((t->ea == ea + 4) && abs(t->hit_count - ttest->hit_count) < 2) {
 			t->valid = 0;
 			ea = t->ea;
 			ttest->size++;


### PR DESCRIPTION
Sometimes we are off by just 1 due to starting or ending a qtrace half
way through a basic block.  This tries harder to match these that are
off by 1.

Signed-off-by: Michael Neuling <mikey@neuling.org>