### PR TITLE
qtbuild: Fix build error with new versions of binutils

### DIFF
--- a/qtbuild/qtbuild.c
+++ b/qtbuild/qtbuild.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <config.h>
 #include <bfd.h>
 #include <dis-asm.h>
 #include <sys/mman.h>


### PR DESCRIPTION
When building with the Advance Toolchain (binutils 2.30) we get the
error: '#error config.h must be included before this header'.

This is a common issue when including bfd.h outside on binutils. We can fix this two ways:
- including config.h before bfd.h 
or
- defining PACKAGE to be some value (bfd.h checks if this is defined to decide if config.h should be already included)