### PR TITLE
qtbuild: Build with newer binutils

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,19 @@ else
 	AC_DEFINE([BFD_NEW_DISASSEMBLER_ARGS], [1], [bfd library uses new disassembler args])
 fi
 
+AC_MSG_CHECKING([binutils version])
+AC_COMPILE_IFELSE(
+	[AC_LANG_SOURCE([[#include <bfd.h>
+					  #include <stdlib.h>
+					  int main(int argc, char** argv) {
+					  asection *sec = malloc(sizeof(*sec));
+					  bfd_section_size(sec);
+					  free(sec);
+					  return 0;} ]])],
+	[AC_MSG_RESULT([2.34 or higher])
+		AC_DEFINE([HAVE_BFD_SECTION_SIZE_1_ARG], [1], [version of bfd that uses 1 arg api])],
+	[AC_MSG_RESULT([2.33 or earlier])])
+
 AC_C_BIGENDIAN(dnl
 	AC_DEFINE([HAVE_BIG_ENDIAN], [1], [Big endian]),dnl
 	AC_DEFINE([HAVE_LITTLE_ENDIAN], [1], [Little endian])dnl

--- a/qtbuild/qtbuild.c
+++ b/qtbuild/qtbuild.c
@@ -96,9 +96,15 @@ static void build(bfd *abfd)
 		exit(1);
 	}
 
+#ifdef HAVE_BFD_SECTION_SIZE_1_ARG
+	text_size = bfd_section_size(text_section);
+	insnmap_size = bfd_section_size(insnmap_section);
+	ldstmap_size = bfd_section_size(ldstmap_section);
+#else
 	text_size = bfd_section_size(bfd, text_section);
 	insnmap_size = bfd_section_size(bfd, insnmap_section);
 	ldstmap_size = bfd_section_size(bfd, ldstmap_section);
+#endif
 
 	text_buf = malloc(text_size);
 	insnmap_buf = malloc(insnmap_size + sizeof(struct insn_map));


### PR DESCRIPTION
In binutils v2.34 the api of bfd_section_size has changed.
Changed in commit:fd3619828e94a24a92cddec42cbc0ab33352eeb4.