### PR TITLE
Fix build failure on RHEL8

### DIFF
--- a/ptracer/ascii.h
+++ b/ptracer/ascii.h
@@ -5,7 +5,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-FILE *ascii_fout;
+extern FILE *ascii_fout;
 
 void ascii_open(char *filename);
 void ascii_close(void);


### PR DESCRIPTION
...with Advance Toolchain 14.0...
```
/opt/at14.0/lib/gcc/powerpc64le-linux-gnu/10.2.1/../../../../powerpc64le-linux-gnu/bin/ld: ptracer/main.o:/home/pc/qtrace-tools/ptracer/ascii.h:8: multiple definition of `ascii_fout'; ptracer/ascii.o:/home/pc/qtrace-tools/ptracer/ascii.c:12: first defined here
```

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>