### PR TITLE
ascii_fout must be extern

### DIFF
--- a/ptracer/ascii.h
+++ b/ptracer/ascii.h
@@ -5,7 +5,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-FILE *ascii_fout;
+extern FILE *ascii_fout;
 
 void ascii_open(char *filename);
 void ascii_close(void);


### PR DESCRIPTION
Without this patch, the build fails with:
/usr/bin/ld: ptracer/main.o:ptracer/ascii.h:8: multiple definition of `ascii_fout'; ptracer/ascii.o:ascii.c:12: first defined here

This is due to there being a new declaration of ascii_fout each time the header is included.

Signed-off-by: Alastair D'Silva <alastair@d-silva.org>