### PR TITLE
Add the Exception Termination Code to qtrace library

### DIFF
--- a/qtlib/qtrace.h
+++ b/qtlib/qtrace.h
@@ -70,6 +70,7 @@
 /* Termination codes */
 #define QTRACE_EXCEEDED_MAX_INST_DEPTH			0x40
 #define QTRACE_EXCEEDED_MAX_BRANCH_DEPTH		0x80
+#define QTRACE_EXCEPTION				0x10
 #define QTRACE_UNCONDITIONAL_BRANCH			0x08
 
 /* 4 level radix */

--- a/qtlib/qtreader.c
+++ b/qtlib/qtreader.c
@@ -620,6 +620,8 @@ bool qtreader_next_record(struct qtreader_state *state, struct qtrace_record *re
 			record->conditional_branch = true;
 		} else if (record->term_code == QTRACE_UNCONDITIONAL_BRANCH) {
 			record->conditional_branch = false;
+		} else if (record->term_code == QTRACE_EXCEPTION) {
+			record->conditional_branch = false;
 		} else {
 			printf("Inconsistent branch\n");
 			goto err;

--- a/qtlib/qtwriter.c
+++ b/qtlib/qtwriter.c
@@ -267,6 +267,8 @@ bool qtwriter_write_record(struct qtwriter_state *state,
 				termination_code = QTRACE_EXCEEDED_MAX_BRANCH_DEPTH;
 			else
 				termination_code = QTRACE_UNCONDITIONAL_BRANCH;
+		} else {
+			termination_code = QTRACE_EXCEPTION;
 		}
 
 		put8(state, termination_code);


### PR DESCRIPTION
Currently qtwriter outputs the termination code of a terminating record
as zero unless the previous instruction had a branch opcode. That means
if an exception is taken the termination code will be zero.

This causes issues with qtreader. If a record has
QTRACE_TERMINATION_PRESENT set and has a termination code of zero then
this is an error which will halt processing.

For example:

	$ qtdis -s example-with-exception.qt
	Inconsistent branch

	Instructions:
	  Total           23709
	    System             526	  2.22% of Total
	      Idle               0	  0.00% of System
	    OPAL                 0	  0.00% of Total
	    User             23183	 97.78% of Total
	      Bin            21019	 90.67% of User
	      Lib             2164	  9.33% of User

	Context Switches:        0

	Exceptions:              1
		System Call/HCALL	1

	Syscalls:                1
			    exit	1

	OPAL Calls:              0

	HCALLS Calls:            0

Fix this by adding the QTRACE_EXCEPTION termination code from the qtrace
format to qtwriter and qtreader. qtraces previously made with htmdecoder
should be regenerated to correctly terminate exceptions.

Signed-off-by: Jordan Niethe <jniethe5@gmail.com>