### PR TITLE
added support for parsing compressed qtraces

### DIFF
--- a/qtlib/qtreader.h
+++ b/qtlib/qtreader.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <archive.h>
 
 #include "qtrace_record.h"
 
@@ -48,10 +49,15 @@ struct qtreader_state {
 	uint64_t radix_insn_ptes[NR_RADIX_PTES];
 	unsigned int radix_nr_insn_ptes;
 	uint64_t radix_data_ptes[NR_RADIX_PTES];
+
+    void *buf_wrt;
+    struct archive *archive;
+    bool archive_end;
 };
 
 bool qtreader_initialize(struct qtreader_state *state, void *mem, size_t size, unsigned int verbose);
 bool qtreader_initialize_fd(struct qtreader_state *state, int fd, unsigned int verbose);
+bool qtreader_initialize_fd_compressed(struct qtreader_state *state, int fd, unsigned int verbose);
 
 static inline uint32_t qtreader_version(struct qtreader_state *state)
 {
@@ -84,6 +90,7 @@ static inline void qtreader_clear_tlbie_info(struct qtreader_state *state)
 }
 
 bool qtreader_next_record(struct qtreader_state *state, struct qtrace_record *record);
+bool qtreader_next_record_compressed(struct qtreader_state *state, struct qtrace_record *record);
 void qtreader_destroy(struct qtreader_state *state);
 
 #ifdef __cplusplus

--- a/qtlib/tests/test5.c
+++ b/qtlib/tests/test5.c
@@ -1,0 +1,77 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
+
+#include "qtreader.h"
+
+int main(int argc, char *argv[])
+{
+	int fd_a, fd_b;
+	struct qtreader_state state_a, state_b;
+	struct qtrace_record record_a, record_b;
+    bool r_a, r_b;
+
+	fd_a = open(argv[1], O_RDONLY);
+	if (fd_a < 0) {
+		perror("open A");
+		exit(1);
+	}
+
+	fd_b = open(argv[2], O_RDONLY);
+	if (fd_b < 0) {
+		perror("open B");
+		exit(1);
+	}
+
+	if (qtreader_initialize_fd(&state_a, fd_a, 0) == false) {
+		fprintf(stderr, "qtreader_initialize_fd failed\n");
+		exit(1);
+	}
+
+	if (qtreader_initialize_fd_compressed(&state_b, fd_b, 0) == false) {
+		fprintf(stderr, "qtreader_initialize_fd_compressed failed\n");
+		exit(1);
+	}
+
+    do {
+        r_a = qtreader_next_record(&state_a, &record_a);
+        r_b = qtreader_next_record_compressed(&state_b, &record_b);
+
+        if (r_a != r_b) {
+            fprintf(stderr, "A(%d) and B(%d) different lengths\n", r_a, r_b);
+            /*
+            if (r_a) {
+                while (qtreader_next_record(&state_a, &record_a)) {
+                    printf("0x%08x\n", record_a.insn);
+                }
+            }
+            if (r_b) {
+                while (qtreader_next_record_compressed(&state_b, &record_b)) {
+                    printf("0x%08x\n", record_b.insn);
+                }
+            }
+            */
+            exit(1);
+        }
+
+        if (r_a && r_b) {
+            if (memcmp(&record_a, &record_b,
+                        sizeof(struct qtrace_record)) != 0) {
+                fprintf(stderr, "record mismatch\n");
+                exit(1);
+            }
+        }
+
+    } while (r_a && r_b);
+
+    printf("qtrace match\n");
+    qtreader_destroy(&state_a);
+    qtreader_destroy(&state_b);
+
+	return 0;
+}


### PR DESCRIPTION
The code uses archive.h to support reading compressed files.  It is based off the old archive support code from before the merging of `qtdis` into `qtreader`.

I wasn't sure the best way to handle determining whether to read compressed vs. uncompressed so I left that up to the user and added:
  `qtreader_initialize_fd_compressed`
  `qtreader_next_record_compressed`
and assumed the user would call the correct one.  Perhaps `qtreader_next_record_compressed` could be removed, but I wasn't sure how to automatically determine if the qtrace file was compressed and the initialization of the compressed `qtreader_state` is a bit different.

I also added a `test5.c` that compares an uncompressed (arg1) qtrace to a compressed (arg2) qtrace and ensures that the lengths and records from each are the same.  I ran it on a couple qtraces with bz2 compression and it worked.